### PR TITLE
fix: downgrade `patchelf` to 0.17.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,15 +29,15 @@ http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "ht
 http_archive(
     name = "patchelf_linux_amd64",
     build_file_content = "alias(name='patchelf', actual='bin/patchelf')",
-    integrity = "sha256-zoTyRH+3qGeeWLxUog3CsBs3tYAuEsV+7OdypvFL8/A=",
-    urls = ["https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-x86_64.tar.gz"],
+    integrity = "sha256-o/ucHeNRK8kfJ8xHKX1tbPIIre6bZO1xkTDaWawT4ms=",
+    urls = ["https://github.com/NixOS/patchelf/releases/download/0.17.2/patchelf-0.17.2-x86_64.tar.gz"],
 )
 
 http_archive(
     name = "patchelf_linux_arm64",
     build_file_content = "alias(name='patchelf', actual='bin/patchelf')",
-    integrity = "sha256-rhPi7/4HfoKb51kYI5a5Mdj4XPuc/p1JOFUW6jZ+97I=",
-    urls = ["https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-aarch64.tar.gz"],
+    integrity = "sha256-5RZetZKjF+H22grH/LzPYNf7jlrB8NczapvlHCMwiwY=",
+    urls = ["https://github.com/NixOS/patchelf/releases/download/0.17.2/patchelf-0.17.2-aarch64.tar.gz"],
 )
 
 bazel_lib_toolchains = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")


### PR DESCRIPTION
For older Ubuntu versions `patchelf` 0.18.0 seems to break things. See https://github.com/NixOS/patchelf/issues/492.

There is a fix available, but no 0.19.0 cut yet.