### PR TITLE
Add "missing ELF header" condition in rpath fixup

### DIFF
--- a/apt/private/deb_install.bzl
+++ b/apt/private/deb_install.bzl
@@ -91,6 +91,8 @@ def _fixup_rpath(rctx, patchelf, path, lib_paths):
             return
         if "patchelf: wrong ELF type" in result.stderr:
             return
+        if "patchelf: missing ELF header" in result.stderr:
+            return
         fail("Failed to add RPATH: {} ({}, {}, {})".format(
             " ".join(cmd),
             result.return_code,


### PR DESCRIPTION
I encountered an unexpected error `patchelf: missing ELF header` when `_fixup_rpath` was attempting to fix `libc++` from LLVM.

Adding this to the list of existing error conditions fixed the issue.