### PR TITLE
feat: support user-defined build_file template substitutions

### DIFF
--- a/apt/extensions.bzl
+++ b/apt/extensions.bzl
@@ -102,6 +102,7 @@ def _apt_extension(module_ctx):
                         add_files = cfg.add_files,
                         post_install_cmd = cfg.post_install_cmd,
                         build_file = cfg.build_file,
+                        build_file_substitutions = cfg.build_file_substitutions,
                         glob_pattern = cfg.glob_pattern,
                         glob_excludes = cfg.glob_excludes,
                     )
@@ -219,6 +220,10 @@ INSTALL_ATTR = {
     "build_file": attr.label(
         doc = "Experimental: BUILD.bazel template for the generated install dir.",
         default = "//apt:install.BUILD.bazel.tmpl",
+    ),
+    "build_file_substitutions": attr.string_dict(
+        doc = "Experimental: additional substitutions to apply to the `build_file` template.",
+        default = {},
     ),
     "glob_pattern": attr.string_list(
         doc = "Experimental: `glob()` pattern for the default `build_file` template.",

--- a/apt/private/deb_install.bzl
+++ b/apt/private/deb_install.bzl
@@ -226,7 +226,7 @@ def _deb_install_impl(rctx):
             "{target_name}": rctx.attr.source,
             "{glob_pattern}": ", ".join([repr(p) for p in rctx.attr.glob_pattern]),
             "{glob_excludes}": ", ".join([repr(p) for p in rctx.attr.glob_excludes]),
-        },
+        } | rctx.attr.build_file_substitutions,
         executable = False,
     )
 
@@ -243,6 +243,7 @@ deb_install = repository_rule(
         "add_files": attr.string_keyed_label_dict(mandatory = True),
         "post_install_cmd": attr.string_list_dict(mandatory = True),
         "build_file": attr.label(mandatory = True),
+        "build_file_substitutions": attr.string_dict(mandatory = True),
         "glob_pattern": attr.string_list(mandatory = True),
         "glob_excludes": attr.string_list(mandatory = True),
     },

--- a/e2e/systemd/BUILD
+++ b/e2e/systemd/BUILD
@@ -1,7 +1,13 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 
 diff_test(
     name = "manifest",
     file1 = "@systemd//:manifest",
     file2 = "expected_manifest.json",
+)
+
+build_test(
+    name = "build_file_substitutions",
+    targets = ["@systemd//:test_alias"],
 )

--- a/e2e/systemd/MODULE.bazel
+++ b/e2e/systemd/MODULE.bazel
@@ -15,6 +15,8 @@ apt = use_extension(
 apt.debian(
     name = "systemd",
     architectures = ["amd64"],
+    build_file = "//:custom.BUILD.bazel.tmpl",
+    build_file_substitutions = {"{custom_alias}": "test_alias"},
     glob_excludes = [
         "usr/share/man/**",
         "**/*cryptsetup.slice",

--- a/e2e/systemd/custom.BUILD.bazel.tmpl
+++ b/e2e/systemd/custom.BUILD.bazel.tmpl
@@ -1,0 +1,13 @@
+"""Custom template used to exercise build_file_substitutions."""
+
+package(default_visibility = ["//visibility:public"])
+
+alias(
+    name = "{custom_alias}",
+    actual = "lib/systemd/systemd",
+)
+
+alias(
+    name = "manifest",
+    actual = "install_manifest.json",
+)


### PR DESCRIPTION
Add a `build_file_substitutions` attr to install tags, merged on top of the default subs when rendering a custom `build_file` template.

This is useful e.g. when using Starlark variables in other attributes that the build file should be aware of:

```py
apt.ubuntu(
    packages = [
        "clang-%s" % LLVM_VERSION,
    ],
    build_file = "...",
    build_file_substitutions = {"{LLVM_VERSION}": LLVM_VERSION},
    ...
)
```

