### PR TITLE
Add "missing ELF header" condition in interpreter fixup

### DIFF
--- a/apt/private/deb_install.bzl
+++ b/apt/private/deb_install.bzl
@@ -110,6 +110,8 @@ def _fixup_interpreter(rctx, patchelf, path, interpreter):
             return
         if "patchelf: wrong ELF type" in result.stderr:
             return
+        if "patchelf: missing ELF header" in result.stderr:
+            return
         fail("Failed to set interpreter: {} ({}, {}, {})".format(
             " ".join(cmd),
             result.return_code,


### PR DESCRIPTION
Add the fix from #182 to `_fixup_interpreter` as well.